### PR TITLE
Kyle baran bug31

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -308,28 +308,39 @@ update_flag
 		onclose(usr, "canister")
 		return
 	usr.set_machine(src)
-	if(href_list["toggle"])
-		var/logmsg
-		if (valve_open)
-			if (holding)
-				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the [holding]<br>"
-			else
-				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the <span class='boldannounce'>air</span><br>"
-		else
+	
+	if(href_list["open_valve"])
+		if (!valve_open)
+			var/logmsg
 			if (holding)
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting the transfer into the [holding]<br>"
 			else
 				logmsg = "Valve was <b>opened</b> by [key_name(usr)], starting the transfer into the <span class='boldannounce'>air</span><br>"
+				
 				if(air_contents.toxins > 0)
 					message_admins("[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) opened a canister that contains plasma! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 					log_admin("[key_name(usr)] opened a canister that contains plasma at [x], [y], [z]")
+					
 				var/datum/gas/sleeping_agent = locate(/datum/gas/sleeping_agent) in air_contents.trace_gases
 				if(sleeping_agent && (sleeping_agent.moles > 1))
 					message_admins("[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) opened a canister that contains N2O! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 					log_admin("[key_name(usr)] opened a canister that contains N2O at [x], [y], [z]")
-		investigate_log(logmsg, "atmos")
-		release_log += logmsg
-		valve_open = !valve_open
+					
+			investigate_log(logmsg, "atmos")
+			release_log += logmsg
+			valve_open = 1 // open the valve
+	
+	if(href_list["close_valve"])
+		if (valve_open)
+			var/logmsg
+			if (holding)
+				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the [holding]<br>"
+			else
+				logmsg = "Valve was <b>closed</b> by [key_name(usr)], stopping the transfer into the <span class='boldannounce'>air</span><br>"
+
+			investigate_log(logmsg, "atmos")
+			release_log += logmsg
+			valve_open = 0 // close the valve
 
 	if (href_list["remove_tank"])
 		if(holding)

--- a/nano/templates/canister.tmpl
+++ b/nano/templates/canister.tmpl
@@ -77,7 +77,6 @@
 		Release Valve:
 	</div>
 	<div class="itemContent">
-		{{:~link('Open', 'unlocked', {'toggle' : 1}, valveOpen ? 'selected' : null)}}{{:~link('Close', 'locked', {'toggle' : 1}, valveOpen ? null : 'selected')}}
+		{{:~link('Open', 'unlocked', {'open_valve' : 1}, valveOpen ? 'selected' : null)}}{{:~link('Close', 'locked', {'close_valve' : 1}, valveOpen ? null : 'selected')}}
 	</div>
 </div>
-


### PR DESCRIPTION
Attempted to fix Bug #31:
>On the current GUI system for canisters and whatever. If you press Close twice on a canister, it will switch twice and end up in open if it's still loading

Unable to test if it actually was fixed, due to it being lag-related. However, canisters still correctly open/close and log activities.